### PR TITLE
Fix memory/resource leak in download process

### DIFF
--- a/utils/download_file.py
+++ b/utils/download_file.py
@@ -48,7 +48,7 @@ def download_file(url, dest, hash=None, retries=3):
 
     th.join()
 
-    res = RES[key]
+    res = RES.pop(key)
     if isinstance(res, Exception):
         msg = f"[{type(res).__name__}] Error retrieving {url}"
         log.error(msg)


### PR DESCRIPTION
Somehow my library ended up messed up, so I tried using the revalidate button. However that would eventually fail and spit `Too many open files` errors to my console.

It turns out that when downloading files, the request objects were staying in the global store and weren't getting freed. This caused a memory leak, but was more importantly causing Blender to eat up file descriptors until it eventually hit its limit.

This fixes that.