### PR TITLE
Fix enable crash on Blender 5.x

### DIFF
--- a/addon_updater_ops.py
+++ b/addon_updater_ops.py
@@ -83,7 +83,7 @@ def make_annotations(cls):
     """Add annotation attribute to fields to avoid Blender 2.8+ warnings"""
     if not hasattr(bpy.app, "version") or bpy.app.version < (2, 80):
         return cls
-    if bpy.app.version >= (3, 0, 0):
+    if bpy.app.version >= (5, 0, 0):
         return cls
     if bpy.app.version < (2, 93, 0):
         bl_props = {k: v for k, v in cls.__dict__.items() if isinstance(v, tuple)}

--- a/addon_updater_ops.py
+++ b/addon_updater_ops.py
@@ -83,6 +83,8 @@ def make_annotations(cls):
     """Add annotation attribute to fields to avoid Blender 2.8+ warnings"""
     if not hasattr(bpy.app, "version") or bpy.app.version < (2, 80):
         return cls
+    if bpy.app.version >= (3, 0, 0):
+        return cls
     if bpy.app.version < (2, 93, 0):
         bl_props = {k: v for k, v in cls.__dict__.items() if isinstance(v, tuple)}
     else:


### PR DESCRIPTION
Adds a Blender version check to skip the legacy `__annotations__` rewrite in `make_annotations`. It crashes on newer Blender because Python 3.14 stores annotations differently than the old code expects.

Blender 3.x+ handles class-level bpy.props on its own, so the rewrite isn't needed. Tested on Blender 5.1.2.